### PR TITLE
Reference dar specifically for correct mv arguments.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ $(target_dir):
 $(dar):
 	daml build
 	mkdir -p $(@D)
-	mv .daml/dist/*.dar $@
+	mv .daml/dist/dablchat-$(dar_version).dar $@
 
 $(dabl_meta): $(target_dir) dabl-meta.yaml
 	cp dabl-meta.yaml $@


### PR DESCRIPTION
Otherwise, this command fails when a user has older/different version dars. Rare, but possible.