### PR TITLE
python operator pipenv version must match daml-meta version number too

### DIFF
--- a/python/operator/setup.py
+++ b/python/operator/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='dablchat-operator-bot',
-      version='1.8.2',
+      version='1.8.3',
       description='DABL Chat Operator',
       author='Digital Asset',
       license='Apache2',


### PR DESCRIPTION
As a follow-up to https://github.com/digital-asset/dablchat/pull/29, this changes the redundantly specified version in python pipenv to match the checked in dabl-meta yaml version number.