### PR TITLE
fix race condition in user request flow

### DIFF
--- a/dabl-meta.yaml
+++ b/dabl-meta.yaml
@@ -11,7 +11,7 @@ catalog:
     tags: [dabl-sample-app, application]
     icon_file: dabl-chat.png
 subdeployments:
-    - dablchat-model-1.8.3.dar
-    - dablchat-operator-bot-1.8.3.tar.gz
-    - dablchat-ui-1.8.3.zip
-    - dablchat-user-bot-1.8.3.tar.gz
+    - dablchat-model-1.8.4.dar
+    - dablchat-operator-bot-1.8.4.tar.gz
+    - dablchat-ui-1.8.4.zip
+    - dablchat-user-bot-1.8.4.tar.gz

--- a/dabl-meta.yaml
+++ b/dabl-meta.yaml
@@ -1,6 +1,6 @@
 catalog:
     name: dabl-chat
-    version: 0.1.4
+    version: 0.1.5
     short_description: DABL Chat
     description: A straightforward web chat app.
     release_date: 2020-09-30
@@ -11,7 +11,7 @@ catalog:
     tags: [dabl-sample-app, application]
     icon_file: dabl-chat.png
 subdeployments:
-    - dablchat-model-1.8.4.dar
-    - dablchat-operator-bot-1.8.4.tar.gz
-    - dablchat-ui-1.8.4.zip
-    - dablchat-user-bot-1.8.4.tar.gz
+    - dablchat-model-1.8.5.dar
+    - dablchat-operator-bot-1.8.5.tar.gz
+    - dablchat-ui-1.8.5.zip
+    - dablchat-user-bot-1.8.5.tar.gz

--- a/daml.yaml
+++ b/daml.yaml
@@ -1,6 +1,6 @@
 sdk-version: 1.4.0
 name: dablchat
-version: 1.8.4
+version: 1.8.5
 source: daml/Chat/V2.daml
 dependencies:
 - daml-prim

--- a/daml.yaml
+++ b/daml.yaml
@@ -1,7 +1,7 @@
 sdk-version: 1.4.0
 name: dablchat
-version: 1.8.3
-source: daml/Chat/V1.daml
+version: 1.8.4
+source: daml/Chat/V2.daml
 dependencies:
 - daml-prim
 - daml-stdlib

--- a/daml/Chat/V2.daml
+++ b/daml/Chat/V2.daml
@@ -1,9 +1,8 @@
 daml 1.2
-module Chat.V1 where
+module Chat.V2 where
 
 import DA.List as L
 import DA.Next.Map as M
-
 
 template Operator
   with
@@ -16,7 +15,7 @@ template Operator
     maintainer key
 
     controller operator can
-      nonconsuming OperatorInviteUser : ContractId UserInvitation
+      nonconsuming Operator_InviteUser : ContractId UserInvitation
         with
           user : Party
           userName : Text
@@ -24,18 +23,16 @@ template Operator
           create UserInvitation with ..
 
 
-template UserSession
+template UserAccountRequest
   with
     operator : Party
     user : Party
     userName : Text
   where
     signatory user
-    key user : Party
-    maintainer key
 
     controller operator can
-      UserSessionAck : Either (ContractId UserInvitation) (ContractId User)
+      UserAccountRequest_Accept : Either (ContractId UserInvitation) (ContractId User)
         do
           let userKey = (operator, user)
           optUserInvitation <- lookupByKey @UserInvitation userKey
@@ -43,12 +40,12 @@ template UserSession
           case (optUserInvitation, optUser) of
             (None, None) -> do
               (opCid, _) <- fetchByKey @Operator operator
-              userInvitationCid <- exercise opCid OperatorInviteUser with ..
+              userInvitationCid <- exercise opCid Operator_InviteUser with ..
               return $ Left userInvitationCid
             (Some userInvitationCid, _) -> return $ Left userInvitationCid
             (_, Some userCid) -> return $ Right userCid
 
-      UserSessionReject : ()
+      UserAccountRequest_Reject : ()
         do return ()
 
 
@@ -65,7 +62,7 @@ template UserInvitation
     maintainer key._1
 
     controller user can
-      UserInvitationAccept : ContractId User
+      UserInvitation_Accept : ContractId User
         do
           let contacts = M.fromList [(operator, "Operator")]
           create AddressBook with ..
@@ -77,7 +74,7 @@ template UserInvitation
                     chatId = partyToText user, isPublic = False, ..
           create User with ..
 
-      UserInvitationReject : ()
+      UserInvitation_Reject : ()
         do return ()
 
 
@@ -94,14 +91,14 @@ template User
     maintainer key._1
 
     controller user can
-      nonconsuming UserRequestPublicChat : ContractId CreateChatRequest
+      nonconsuming User_RequestPublicChat : ContractId CreateChatRequest
         with
           name : Text
           topic : Optional Text
         do
           create CreateChatRequest with members = [], isPublic = True, ..
 
-      nonconsuming UserRequestPrivateChat : ContractId CreateChatRequest
+      nonconsuming User_RequestPrivateChat : ContractId CreateChatRequest
         with
           name : Text
           members : [Text]
@@ -109,14 +106,14 @@ template User
         do
           create CreateChatRequest with isPublic = False, ..
 
-      nonconsuming UserUpdateSelfAlias : Optional (ContractId SelfAlias)
+      nonconsuming User_UpdateSelfAlias : Optional (ContractId SelfAlias)
         with
           alias : Text
         do
           optAliasCid <- lookupByKey @SelfAlias (operator, user)
           case optAliasCid of
             Some cid | alias /= "" -> do
-                newCid <- exercise cid SelfAliasRename with newAlias = alias
+                newCid <- exercise cid SelfAlias_Rename with newAlias = alias
                 return $ Some newCid
             Some cid | alias == "" -> do
               archive cid
@@ -126,14 +123,14 @@ template User
               return $ Some cid
             _ -> return None
 
-      nonconsuming UserRequestAliases : ContractId AliasesRequest
+      nonconsuming User_RequestAliases : ContractId AliasesRequest
         do create AliasesRequest with ..
 
-      nonconsuming UserRequestArchiveMessages : ContractId ArchiveMessagesRequest
+      nonconsuming User_RequestArchiveMessages : ContractId ArchiveMessagesRequest
         do create ArchiveMessagesRequest with ..
 
     controller operator can
-      UserOffboard : ()
+      User_Offboard : ()
         do return ()
 
 
@@ -170,7 +167,7 @@ template AddressBook
     maintainer key
 
     controller user can
-      AddressBookAdd : ContractId AddressBook
+      AddressBook_Add : ContractId AddressBook
         with
           party : Party
           name : Text
@@ -178,7 +175,7 @@ template AddressBook
           assert $ party /= operator
           create this with contacts = insert party name contacts
 
-      AddressBookRemove : ContractId AddressBook
+      AddressBook_Remove : ContractId AddressBook
         with
           party : Party
         do
@@ -211,7 +208,7 @@ template CreateChatRequest
     signatory operator, user
 
     controller operator can
-      CreateChatRequestRespond : Optional (ContractId Chat)
+      CreateChatRequest_Respond : Optional (ContractId Chat)
         with
           partyMembers : [Party]
           chatId : Text
@@ -223,7 +220,7 @@ template CreateChatRequest
               chatCid <- create Chat with creator = user, members = dedup (user :: partyMembers), ..
               return $ Some chatCid
 
-      CreateChatRequestReject : ()
+      CreateChatRequest_Reject : ()
         do return ()
 
 
@@ -242,14 +239,14 @@ template SelfAlias
     maintainer key._2
 
     controller user can
-      SelfAliasRename : ContractId SelfAlias
+      SelfAlias_Rename : ContractId SelfAlias
         with
           newAlias : Text
         do
           create this with alias = newAlias
 
     controller operator can
-      SelfAliasArchive : ()
+      SelfAlias_Archive : ()
         do return ()
 
 
@@ -274,14 +271,14 @@ template ForwardToSlack
     maintainer key._2
 
     controller user can
-      ForwardToSlackUpdateChannel : ContractId ForwardToSlack
+      ForwardToSlack_UpdateChannel : ContractId ForwardToSlack
         with
           newSlackChannelId : Text
         do
           create this with slackChannelId = newSlackChannelId
 
     controller operator can
-      ForwardToSlackArchive : ()
+      ForwardToSlack_Archive : ()
         do return ()
 
 
@@ -311,7 +308,7 @@ template Chat
     key (chatSignatory, if isPublic then name else chatId) : (Party, Text)
     maintainer key._1
 
-    nonconsuming choice ChatPostMessage : ContractId Message
+    nonconsuming choice Chat_PostMessage : ContractId Message
       with
         poster : Party
         message : Text
@@ -321,7 +318,7 @@ template Chat
         assert $ poster `elem` members
         create Message with sender = poster, recipients = dedup $ chatSignatory :: observers, ..
 
-    choice ChatAddMembers : ContractId Chat
+    choice Chat_AddMembers : ContractId Chat
       with
         member : Party
         newMembers : [Party]
@@ -331,7 +328,7 @@ template Chat
         assert (not $ all (`elem` members) newMembers)
         create this with members = dedup $ newMembers ++ members
 
-    choice ChatRemoveMembers : ContractId Chat
+    choice Chat_RemoveMembers : ContractId Chat
       with
         member : Party
         membersToRemove : [Party]
@@ -346,7 +343,7 @@ template Chat
         do return ()
 
     controller creator can
-      ChatRename : ContractId Chat
+      Chat_Rename : ContractId Chat
         with
           newName : Text
           newTopic : Optional Text
@@ -354,17 +351,17 @@ template Chat
           assert (newName /= name || newTopic /= topic)
           create this with name = newName, topic = newTopic
 
-      ChatArchive : ()
+      Chat_Archive : ()
         do return ()
 
-      nonconsuming ChatForwardToSlack : Optional (ContractId ForwardToSlack)
+      nonconsuming Chat_ForwardToSlack : Optional (ContractId ForwardToSlack)
         with
           slackChannelId : Text
         do
           optForwardToSlack <- lookupByKey @ForwardToSlack (operator, creator, chatId)
           case optForwardToSlack of
             Some cid | slackChannelId /= "" -> do
-                newCid <- exercise cid ForwardToSlackUpdateChannel
+                newCid <- exercise cid ForwardToSlack_UpdateChannel
                   with newSlackChannelId = slackChannelId
                 return $ Some newCid
             Some cid | slackChannelId == "" -> do

--- a/daml/ChatModule.daml
+++ b/daml/ChatModule.daml
@@ -1,0 +1,4 @@
+daml 1.2
+module ChatModule where
+
+import Chat.V2()

--- a/daml/ChatModuleTests.daml
+++ b/daml/ChatModuleTests.daml
@@ -1,0 +1,4 @@
+daml 1.2
+module ChatModuleTests where
+
+import Test.ChatTest.V2()

--- a/daml/Test/ChatTest/V2.daml
+++ b/daml/Test/ChatTest/V2.daml
@@ -1,0 +1,62 @@
+daml 1.2
+module Test.ChatTest.V2 where
+
+import Chat.V2
+
+
+createOperatorTest =
+  scenario do
+    operator <- getParty "operator"
+    publicParty <- getParty "public"
+    createOrUpdateOperatorTestBuilder operator publicParty
+
+
+createUserAccountTest =
+  scenario do
+    operator <- getParty "operator"
+    publicParty <- getParty "public"
+    user <- getParty "user-1"
+    let userName = "first user name"
+    _ <- createOrUpdateOperatorTestBuilder operator publicParty
+    accountRequestCid <- userAccountRequestTestBuilder operator user userName
+    operatorUserRequestAcceptTestBuilder operator accountRequestCid
+
+
+createDuplicatedUserAccountTest =
+  scenario do
+    operator <- getParty "operator"
+    publicParty <- getParty "public"
+    user <- getParty "user-2"
+    let userName = "mr duplicitious"
+    _ <- createOrUpdateOperatorTestBuilder operator publicParty
+    firstAccountRequestCid <- userAccountRequestTestBuilder operator user userName
+    secondAccountRequestCid <- userAccountRequestTestBuilder operator user userName
+    operatorUserRequestAcceptTestBuilder operator firstAccountRequestCid
+    operatorUserRequestAcceptTestBuilder operator secondAccountRequestCid
+
+
+createOrUpdateOperatorTestBuilder : Party -> Party
+  -> Scenario (ContractId Operator)
+createOrUpdateOperatorTestBuilder operator publicParty =
+  scenario do
+    submit operator do
+      operatorOpt <- lookupByKey @Operator operator
+      case operatorOpt of
+        Some operatorCid -> return operatorCid
+        None -> create Operator with ..
+
+
+userAccountRequestTestBuilder : Party -> Party -> Text
+  -> Scenario (ContractId UserAccountRequest)
+userAccountRequestTestBuilder operator user userName =
+  scenario do
+    submit user do
+      create UserAccountRequest with ..
+
+
+operatorUserRequestAcceptTestBuilder : Party -> (ContractId UserAccountRequest)
+  -> Scenario (Either (ContractId UserInvitation) (ContractId User))
+operatorUserRequestAcceptTestBuilder operator userSessionCid =
+  scenario do
+    submit operator do
+      exercise userSessionCid UserAccountRequest_Accept

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dablchat",
-  "version": "1.8.4",
+  "version": "1.8.5",
   "private": true,
   "dependencies": {
     "@webscopeio/react-textarea-autocomplete": "^4.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dablchat",
-  "version": "1.8.3",
+  "version": "1.8.4",
   "private": true,
   "dependencies": {
     "@webscopeio/react-textarea-autocomplete": "^4.6.1",

--- a/python/operator/setup.py
+++ b/python/operator/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='dablchat-operator-bot',
-      version='1.8.3',
+      version='1.8.4',
       description='DABL Chat Operator',
       author='Digital Asset',
       license='Apache2',

--- a/python/operator/setup.py
+++ b/python/operator/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='dablchat-operator-bot',
-      version='1.8.4',
+      version='1.8.5',
       description='DABL Chat Operator',
       author='Digital Asset',
       license='Apache2',

--- a/python/user/bot/user_bot.py
+++ b/python/user/bot/user_bot.py
@@ -11,9 +11,9 @@ EPOCH = datetime.datetime.utcfromtimestamp(0)
 
 
 class Chat:
-    ArchiveMessagesRequest = 'Chat.V1:ArchiveMessagesRequest'
-    Message = 'Chat.V1:Message'
-    UserSettings = 'Chat.V1:UserSettings'
+    ArchiveMessagesRequest = 'Chat.V2:ArchiveMessagesRequest'
+    Message = 'Chat.V2:Message'
+    UserSettings = 'Chat.V2:UserSettings'
 
 
 def main():

--- a/python/user/setup.py
+++ b/python/user/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='dablchat-user-bot',
-      version='1.8.4',
+      version='1.8.5',
       description='DABL Chat User',
       author='Digital Asset',
       license='Apache2',

--- a/python/user/setup.py
+++ b/python/user/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='dablchat-user-bot',
-      version='1.8.3',
+      version='1.8.4',
       description='DABL Chat User',
       author='Digital Asset',
       license='Apache2',

--- a/src/ChatManager.js
+++ b/src/ChatManager.js
@@ -24,13 +24,13 @@ function sleep(ms) {
 
 async function ChatManager(party, token, updateUser, updateState) {
 
-  const ADDRESS_BOOK_TEMPLATE = 'Chat.V1:AddressBook'
-  const CHAT_TEMPLATE = 'Chat.V1:Chat'
-  const MESSAGE_TEMPLATE = 'Chat.V1:Message'
-  const SELF_ALIAS_TEMPLATE = 'Chat.V1:SelfAlias'
-  const USER_TEMPLATE = 'Chat.V1:User'
-  const USER_INVITATION_TEMPLATE = 'Chat.V1:UserInvitation'
-  const USER_SESSION_TEMPLATE = 'Chat.V1:UserSession'
+  const ADDRESS_BOOK_TEMPLATE = 'Chat.V2:AddressBook'
+  const CHAT_TEMPLATE = 'Chat.V2:Chat'
+  const MESSAGE_TEMPLATE = 'Chat.V2:Message'
+  const SELF_ALIAS_TEMPLATE = 'Chat.V2:SelfAlias'
+  const USER_TEMPLATE = 'Chat.V2:User'
+  const USER_INVITATION_TEMPLATE = 'Chat.V2:UserInvitation'
+  const USER_ACCOUNT_REQUEST_TEMPLATE = 'Chat.V2:UserAccountRequest'
 
   const headers = {
     "Authorization": `Bearer ${token.toString()}`,
@@ -70,10 +70,10 @@ async function ChatManager(party, token, updateUser, updateState) {
     return dablJson
   }
 
-  const createSession = async (operator, userName) => {
+  const createUserAccountRequest = async (operator, userName) => {
     return post('/v1/create', {
       body: JSON.stringify({
-        templateId: USER_SESSION_TEMPLATE,
+        templateId: USER_ACCOUNT_REQUEST_TEMPLATE,
         payload: {
           operator,
           user: party,
@@ -102,9 +102,9 @@ async function ChatManager(party, token, updateUser, updateState) {
   }
 
   const userName = parseUserName(token)
-  const createSessionResponse = await createSession(operatorId, userName);
+  const createUserAccountRequestResponse = await createUserAccountRequest(operatorId, userName);
 
-  switch (createSessionResponse.status) {
+  switch (createUserAccountRequestResponse.status) {
     case 401:
       throw new Error("Authentication failed")
     case 404:
@@ -221,7 +221,7 @@ async function ChatManager(party, token, updateUser, updateState) {
       body: JSON.stringify({
         templateId: USER_INVITATION_TEMPLATE,
         contractId: userInvitation.contractId,
-        choice: 'UserInvitationAccept',
+        choice: 'UserInvitation_Accept',
         argument: {}
       })
     })
@@ -234,7 +234,7 @@ async function ChatManager(party, token, updateUser, updateState) {
       body: JSON.stringify({
         templateId: CHAT_TEMPLATE,
         contractId: chat.contractId,
-        choice: 'ChatPostMessage',
+        choice: 'Chat_PostMessage',
         argument: {
           poster: user.user,
           message: message,
@@ -249,7 +249,7 @@ async function ChatManager(party, token, updateUser, updateState) {
       body: JSON.stringify({
         templateId: USER_TEMPLATE,
         contractId: user.contractId,
-        choice: 'UserRequestPrivateChat',
+        choice: 'User_RequestPrivateChat',
         argument: {
           name : name,
           members : members,
@@ -264,7 +264,7 @@ async function ChatManager(party, token, updateUser, updateState) {
       body: JSON.stringify({
         templateId: USER_TEMPLATE,
         contractId: user.contractId,
-        choice: 'UserRequestPublicChat',
+        choice: 'User_RequestPublicChat',
         argument: {
           name : name,
           topic : topic
@@ -278,7 +278,7 @@ async function ChatManager(party, token, updateUser, updateState) {
       body: JSON.stringify({
         templateId: CHAT_TEMPLATE,
         contractId: chat.contractId,
-        choice: 'ChatAddMembers',
+        choice: 'Chat_AddMembers',
         argument: {
           member: user.user,
           newMembers: newMembers
@@ -292,7 +292,7 @@ async function ChatManager(party, token, updateUser, updateState) {
       body: JSON.stringify({
         templateId: CHAT_TEMPLATE,
         contractId: chat.contractId,
-        choice: 'ChatRemoveMembers',
+        choice: 'Chat_RemoveMembers',
         argument: {
           member: user.user,
           membersToRemove: membersToRemove
@@ -306,7 +306,7 @@ async function ChatManager(party, token, updateUser, updateState) {
       body: JSON.stringify({
         templateId: USER_TEMPLATE,
         contractId: user.contractId,
-        choice: 'UserUpdateSelfAlias',
+        choice: 'User_UpdateSelfAlias',
         argument: {
           alias
         }
@@ -319,7 +319,7 @@ async function ChatManager(party, token, updateUser, updateState) {
       body: JSON.stringify({
         templateId: ADDRESS_BOOK_TEMPLATE,
         key: user.user,
-        choice: 'AddressBookAdd',
+        choice: 'AddressBook_Add',
         argument: {
           party,
           name
@@ -333,7 +333,7 @@ async function ChatManager(party, token, updateUser, updateState) {
       body: JSON.stringify({
         templateId: ADDRESS_BOOK_TEMPLATE,
         key: user.user,
-        choice: 'AddressBookRemove',
+        choice: 'AddressBook_Remove',
         argument: {
           party
         }
@@ -346,7 +346,7 @@ async function ChatManager(party, token, updateUser, updateState) {
       body: JSON.stringify({
         templateId: USER_TEMPLATE,
         contractId: user.contractId,
-        choice: 'UserRequestAliases',
+        choice: 'User_RequestAliases',
         argument: {}
       })
     })
@@ -357,7 +357,7 @@ async function ChatManager(party, token, updateUser, updateState) {
       body: JSON.stringify({
         templateId: CHAT_TEMPLATE,
         contractId: chat.contractId,
-        choice: 'ChatRename',
+        choice: 'Chat_Rename',
         argument: {
           newName: newName,
           newTopic: newTopic
@@ -371,7 +371,7 @@ async function ChatManager(party, token, updateUser, updateState) {
       body: JSON.stringify({
         templateId: CHAT_TEMPLATE,
         contractId: chat.contractId,
-        choice: 'ChatArchive',
+        choice: 'Chat_Archive',
         argument: {}
       })
     })
@@ -382,7 +382,7 @@ async function ChatManager(party, token, updateUser, updateState) {
       body: JSON.stringify({
         templateId: CHAT_TEMPLATE,
         contractId: chat.contractId,
-        choice: 'ChatForwardToSlack',
+        choice: 'Chat_ForwardToSlack',
         argument: {
           slackChannelId
         }


### PR DESCRIPTION
## Overview

This fixes the current race condition between bot initialization and initial user login. It works by renaming the `UserSession` contract to `UserAccountRequest` and removes the contract key constraint. Finally, the bot startup deduplicates pending `UserAccountRequests` by the 'user' party field, accepting the first request per 'user' party and archiving the rest, as an optimization.

## Testing Done

* I deployed this to the master cluster and logged in before the bot was running. Instead of an "Internal Server Error," logins begin to succeed once the bot initializes. We could separately address the messaging when a timeout occurs during initial login.
* I also added a DAML scenario to test duplicated user account request submission and acceptance.

## Related

* fixes https://github.com/digital-asset/dablchat/issues/30.

