### PR TITLE
Add `run-` targets to the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,14 +3,20 @@ VERSION=4.0.0
 python := poetry run python
 
 pkg_bot := dist/daml-chat-$(VERSION).tar.gz
-pkg_dit := daml-chat-$(VERSION).ddit
+pkg_dit := daml-chat-$(VERSION).dit
+
+pkg_bot := dist/daml_chat-$(VERSION).tar.gz
+pkg_ui := dist/web.zip
+all_pkgs := $(pkg_bot) $(pkg_ui)
+
+daml_src := daml.yaml $(shell find daml -name '*.daml')
 
 .PHONY: all
 all: package
 
 .PHONY: clean
 clean:
-	rm -fr .daml dist
+	rm -fr .daml dist "$(pkg_dit)"
 
 .PHONY: format
 format: .venv/poetry.lock
@@ -27,30 +33,44 @@ test: .venv/poetry.lock
 	poetry install
 	cp poetry.lock "$@"
 
-.PHONY: build
-build: $(pkg_bot)
+node_modules/package.json:
+	npm install
+	cp package.json "$@"
 
-$(pkg_bot): pyproject.toml $(shell find python -name '*.py' -type f)
+.PHONY: build
+build: $(all_pkgs)
+
+.PHONY: build-bot
+build-bot: $(pkg_bot)
+$(pkg_bot): .venv/poetry.lock pyproject.toml $(shell find python -name '*.py' -type f)
 	poetry build -f sdist
+
+.PHONY: build-ui
+build-ui: $(pkg_ui)
+$(pkg_ui): node_modules/package.json $(daml_src)
+	npm run build
+	(cd "$(@D)" && zip -r "$(@F)" web)
 
 .PHONY: run-ledger
 run-ledger:
 	daml start
 
+.PHONY: run-bot
+run-bot: .venv/poetry.lock
+	DAML_LEDGER_URL="http://localhost:6865" poetry run python -m bot
+
+.PHONY:
+run-ui: node_modules/package.json .venv/poetry.lock
+	npm run build
+	poetry run python3 -m http.server -d dist/web
+
 .PHONY: package
 package: $(pkg_dit)
-$(pkg_dit): dit-meta.yaml $(pkg_bot) $(pkg_bot)
-	poetry run ddit build \
-	   --subdeployment $(pkg_bot) $(pkg_bot)
-
-# $(ui): $(user_bot)
-# 	npm install
-# 	REACT_APP_ARCHIVE_BOT_HASH=$(shell sha256sum $(user_bot) | awk '{print $$1}') npm build
-# 	zip -r daml-chat-ui-$(VERSION).zip build
-# 	mkdir -p $(@D)
-# 	mv daml-chat-ui-$(VERSION).zip $@
-# 	rm -r build
+$(pkg_dit): .venv/poetry.lock dit-meta.yaml $(all_pkgs)
+	@# $(pkg_dar) is intentionally left out because ddit includes it for free
+	-rm "$(pkg_dit)"
+	poetry run ddit build --subdeployment $(all_pkgs)
 
 .PHONY: publish
-publish: package
+publish: .venv/poetry.lock $(pkg_dit)
 	poetry run ddit release

--- a/dit-meta.yaml
+++ b/dit-meta.yaml
@@ -1,6 +1,6 @@
 catalog:
   name: daml-chat
-  version: 2.0.2
+  version: 4.0.0
   short_description: Daml Chat
   description: A straightforward web chat app.
   author: Digital Asset (Switzerland) GmbH

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "vite dev web",
-    "build": "tsc && vite build web",
+    "dev": "daml build && daml codegen js && vite dev web",
+    "build": "daml build && daml codegen js && tsc && vite build web",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
     "preview": "vite preview web"
   },

--- a/python/bot/__main__.py
+++ b/python/bot/__main__.py
@@ -1,0 +1,13 @@
+import asyncio
+import logging
+import os
+
+import damlchat
+import dazl
+
+url = os.getenv("DAML_LEDGER_URL")
+party = os.getenv("DAML_LEDGER_PARTY")
+public_party = os.getenv("DABL_PUBLIC_PARTY")
+
+dazl.setup_default_logger(logging.INFO)
+asyncio.run(damlchat.main(url, party, public_party))

--- a/python/damlchat/__init__.py
+++ b/python/damlchat/__init__.py
@@ -1,3 +1,3 @@
 from .operator_bot import main
 
-main()
+__all__ = ["main"]


### PR DESCRIPTION
More miscellaneous fixes:
* Add more targets to the `Makefile` to run the various parts of the app independently.
* Make the bot runnable both locally (discovering party literals against the User Management API) and in Daml Hub (using environment variables).