### PR TITLE
Fix a bug where new chats couldn't be created.

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -417,7 +417,6 @@ class App extends Component<Props, State> {
 
     if (newMessage.trim() === "") return;
     if (!chatUser) return;
-    if (!currentChat) return;
 
     const match = /\/(\w+)((?:\s*)(.*))?/.exec(newMessage);
     const command = match ? match[1] : "send";
@@ -427,6 +426,8 @@ class App extends Component<Props, State> {
 
     switch (command) {
       case "dm":
+        if (!currentChat) return;
+
         const members = words
           .filter((w) => w.startsWith("@"))
           .map((w) => w.slice(1));


### PR DESCRIPTION
In converting the codebase over to TypeScript, I had to institute a few non-null guards where they weren't there before; I accidentally added one too early, and that caused requests to create chats (when there was no active chat) to be ignored.