### PR TITLE
More typing fixes.

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -571,6 +571,7 @@ class App extends Component<Props, State> {
         this.chatManager.forwardToSlack(chatToForward, slackChannelId);
         break;
       case "giphy":
+        if (!currentChat) return;
         fetch(
           `//api.giphy.com/v1/gifs/random?api_key=${GIPHY_TOKEN}&tag=${encodeURIComponent(
             content,


### PR DESCRIPTION
Missed another guard in #106, and somehow that broken build snuck into `master`… fix that too.

The application isn't necessarily broken because _JavaScript_ doesn't care about this error… it would just result in the same annoying `console.error` that you'd see in Daml Chat 2.0's JavaScript-based app.