### PR TITLE
Use the daml Ledger Client instead of using handcrafted fetch calls.

### DIFF
--- a/web/src/ChatManager.ts
+++ b/web/src/ChatManager.ts
@@ -1,5 +1,6 @@
 import { ContractId, Party } from "@daml/types";
 import * as V4 from "@daml.js/daml-chat/lib/Chat/V4";
+import Ledger from "@daml/ledger";
 
 export interface Chat {
   contractId: ContractId<V4.Chat>;
@@ -129,6 +130,8 @@ async function ChatManager(
   updateUser: (user: User, onboarded: boolean) => void,
   updateState: (user: User, model: Chat[], aliases: Aliases) => void,
 ): Promise<ChatManager> {
+  const ledger = new Ledger({ token });
+
   const headers = {
     Authorization: `Bearer ${token.toString()}`,
     "Content-Type": "application/json",
@@ -188,15 +191,10 @@ async function ChatManager(
     operator: string,
     userName: string,
   ) => {
-    return post("/v1/create", {
-      body: JSON.stringify({
-        templateId: V4.UserAccountRequest.templateId,
-        payload: {
-          operator,
-          user: party,
-          userName,
-        },
-      }),
+    await ledger.create(V4.UserAccountRequest, {
+      operator,
+      user: party,
+      userName,
     });
   };
 
@@ -225,20 +223,7 @@ async function ChatManager(
   };
 
   const userName = parseUserName(token);
-  const createUserAccountRequestResponse = await createUserAccountRequest(
-    operatorId,
-    userName,
-  );
-
-  switch (createUserAccountRequestResponse.status) {
-    case 401:
-      throw new Error("Authentication failed");
-    case 404:
-      throw new Error("HTTP JSON failed");
-    case 500:
-      throw new Error("Internal Server Error");
-    default:
-  }
+  await createUserAccountRequest(operatorId, userName);
 
   try {
     // Make MAX_ATTEMPTS to fetch the user or their invitation
@@ -415,47 +400,30 @@ async function ChatManager(
     enabled: boolean,
     message: string,
   ) => {
-    await post("/v1/exercise", {
-      body: JSON.stringify({
-        templateId: V4.User.templateId,
-        contractId: user.contractId,
-        choice: "User_RequestArchiveBot",
-        argument: {
-          botName: botName,
-          enabled: enabled,
-          message: message,
-        },
-      }),
+    await ledger.exercise(V4.User.User_RequestArchiveBot, user.contractId, {
+      botName,
+      enabled,
+      message,
     });
   };
 
   const updateUserSettings = async (
     user: { contractId: ContractId<V4.User> },
-    timedelta: V4.Duration,
+    newArchiveMessagesAfter: V4.Duration,
   ) => {
-    await post("/v1/exercise", {
-      body: JSON.stringify({
-        templateId: V4.User.templateId,
-        contractId: user.contractId,
-        choice: "User_UpdateUserSettings",
-        argument: {
-          newArchiveMessagesAfter: timedelta,
-        },
-      }),
+    await ledger.exercise(V4.User.User_UpdateUserSettings, user.contractId, {
+      newArchiveMessagesAfter,
     });
   };
 
   const acceptInvitation = async (userInvitation: {
     contractId: ContractId<V4.UserInvitation>;
   }) => {
-    await post("/v1/exercise", {
-      body: JSON.stringify({
-        templateId: V4.UserInvitation.templateId,
-        contractId: userInvitation.contractId,
-        choice: "UserInvitation_Accept",
-        argument: {},
-      }),
-    });
+    await ledger.exercise(
+      V4.UserInvitation.UserInvitation_Accept,
+      userInvitation.contractId,
+      {},
+    );
   };
 
   const sendMessage = async (
@@ -465,17 +433,10 @@ async function ChatManager(
   ) => {
     const d = new Date();
     const seconds = Math.round(d.getTime() / 1000);
-    await post("/v1/exercise", {
-      body: JSON.stringify({
-        templateId: V4.Chat.templateId,
-        contractId: chat.contractId,
-        choice: "Chat_PostMessage",
-        argument: {
-          poster: user.user,
-          message: message,
-          postedAt: seconds,
-        },
-      }),
+    await ledger.exercise(V4.Chat.Chat_PostMessage, chat.contractId, {
+      poster: user.user,
+      message,
+      postedAt: seconds.toString(),
     });
   };
 
@@ -485,17 +446,10 @@ async function ChatManager(
     members: Party[],
     topic: string,
   ) => {
-    await post("/v1/exercise", {
-      body: JSON.stringify({
-        templateId: V4.User.templateId,
-        contractId: user.contractId,
-        choice: "User_RequestPrivateChat",
-        argument: {
-          name: name,
-          members: members,
-          topic: topic,
-        },
-      }),
+    await ledger.exercise(V4.User.User_RequestPrivateChat, user.contractId, {
+      name,
+      members,
+      topic,
     });
   };
 
@@ -504,16 +458,9 @@ async function ChatManager(
     name: string,
     topic: string,
   ) => {
-    await post("/v1/exercise", {
-      body: JSON.stringify({
-        templateId: V4.User.templateId,
-        contractId: user.contractId,
-        choice: "User_RequestPublicChat",
-        argument: {
-          name: name,
-          topic: topic,
-        },
-      }),
+    await ledger.exercise(V4.User.User_RequestPublicChat, user.contractId, {
+      name,
+      topic,
     });
   };
 
@@ -522,16 +469,9 @@ async function ChatManager(
     chat: { contractId: ContractId<V4.Chat> },
     newMembers: Party[],
   ) => {
-    await post("/v1/exercise", {
-      body: JSON.stringify({
-        templateId: V4.Chat.templateId,
-        contractId: chat.contractId,
-        choice: "Chat_AddMembers",
-        argument: {
-          member: user.user,
-          newMembers: newMembers,
-        },
-      }),
+    await ledger.exercise(V4.Chat.Chat_AddMembers, chat.contractId, {
+      member: user.user,
+      newMembers: newMembers,
     });
   };
 
@@ -540,16 +480,9 @@ async function ChatManager(
     chat: { contractId: ContractId<V4.Chat> },
     membersToRemove: Party[],
   ) => {
-    await post("/v1/exercise", {
-      body: JSON.stringify({
-        templateId: V4.Chat.templateId,
-        contractId: chat.contractId,
-        choice: "Chat_RemoveMembers",
-        argument: {
-          member: user.user,
-          membersToRemove: membersToRemove,
-        },
-      }),
+    await ledger.exercise(V4.Chat.Chat_RemoveMembers, chat.contractId, {
+      member: user.user,
+      membersToRemove: membersToRemove,
     });
   };
 
@@ -557,15 +490,8 @@ async function ChatManager(
     user: { contractId: ContractId<V4.User> },
     alias: string,
   ) => {
-    await post("/v1/exercise", {
-      body: JSON.stringify({
-        templateId: V4.User.templateId,
-        contractId: user.contractId,
-        choice: "User_UpdateSelfAlias",
-        argument: {
-          alias,
-        },
-      }),
+    await ledger.exercise(V4.User.User_UpdateSelfAlias, user.contractId, {
+      alias,
     });
   };
 
@@ -574,16 +500,9 @@ async function ChatManager(
     party: Party,
     name: string,
   ) => {
-    await post("/v1/exercise", {
-      body: JSON.stringify({
-        templateId: V4.AddressBook.templateId,
-        key: user.user,
-        choice: "AddressBook_Add",
-        argument: {
-          party,
-          name,
-        },
-      }),
+    await ledger.exerciseByKey(V4.AddressBook.AddressBook_Add, user.user, {
+      party,
+      name,
     });
   };
 
@@ -591,27 +510,13 @@ async function ChatManager(
     user: { user: V4.AddressBook.Key },
     party: Party,
   ) => {
-    await post("/v1/exercise", {
-      body: JSON.stringify({
-        templateId: V4.AddressBook.templateId,
-        key: user.user,
-        choice: "AddressBook_Remove",
-        argument: {
-          party,
-        },
-      }),
+    await ledger.exerciseByKey(V4.AddressBook.AddressBook_Remove, user.user, {
+      party,
     });
   };
 
   const requestUserList = async (user: { contractId: ContractId<V4.User> }) => {
-    await post("/v1/exercise", {
-      body: JSON.stringify({
-        templateId: V4.User.templateId,
-        contractId: user.contractId,
-        choice: "User_RequestAliases",
-        argument: {},
-      }),
-    });
+    await ledger.exercise(V4.User.User_RequestAliases, user.contractId, {});
   };
 
   const renameChat = async (
@@ -619,43 +524,22 @@ async function ChatManager(
     newName: string,
     newTopic: string,
   ) => {
-    await post("/v1/exercise", {
-      body: JSON.stringify({
-        templateId: V4.Chat.templateId,
-        contractId: chat.contractId,
-        choice: "Chat_Rename",
-        argument: {
-          newName: newName,
-          newTopic: newTopic,
-        },
-      }),
+    await ledger.exercise(V4.Chat.Chat_Rename, chat.contractId, {
+      newName,
+      newTopic,
     });
   };
 
   const archiveChat = async (chat: { contractId: ContractId<V4.Chat> }) => {
-    await post("/v1/exercise", {
-      body: JSON.stringify({
-        templateId: V4.Chat.templateId,
-        contractId: chat.contractId,
-        choice: "Chat_Archive",
-        argument: {},
-      }),
-    });
+    await ledger.exercise(V4.Chat.Chat_Archive, chat.contractId, {});
   };
 
   const forwardToSlack = async (
     chat: { contractId: ContractId<V4.Chat> },
     slackChannelId: string,
   ) => {
-    await post("/v1/exercise", {
-      body: JSON.stringify({
-        templateId: V4.Chat.templateId,
-        contractId: chat.contractId,
-        choice: "Chat_ForwardToSlack",
-        argument: {
-          slackChannelId,
-        },
-      }),
+    await ledger.exercise(V4.Chat.Chat_ForwardToSlack, chat.contractId, {
+      slackChannelId,
     });
   };
 


### PR DESCRIPTION
Incorporate the official `@daml/ledger` client into this codebase, and use it for the write path.

I intend to _also_ use these bindings to make User Management 2.x calls, so dipping my toes in the water on an easy change that thankfully also drops some lines of code.

The read side calls are harder to replace because we use both regular party tokens and public-party tokens, and we also make use of multi-template queries (supported over the wire, but not through `@daml/ledger`). I haven't decided how I'll resolve those yet.