### PR TITLE
Drop support for user-deployed auto-archiving bots.

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -34,8 +34,6 @@ const CommandAutoCompleteItem = ({ entity }: { entity: any }) => {
   );
 };
 
-const publicBot = { name: "AutoArchivingBot", hash: "UNUSED" };
-
 const commands = [
   {
     command: "/add @user... [#chat-id]",
@@ -87,11 +85,6 @@ const commands = [
     description:
       "Forward messages of a public chat to a slack channel. (Requires a running Slack Send Message integration and you must be the creator of the chat)",
   },
-  {
-    command: "/bot [on/off] | [5s|m|h|d]",
-    description:
-      "Turning auto-archiving bot on or off or set retention period.",
-  },
 ];
 
 const GIPHY_TOKEN = "kDqbzOZtPvy38TLdqonPnpTPrsLfW8uy";
@@ -129,15 +122,6 @@ const ChatAutoCompleteItem = ({ entity }: { entity: any }) => {
 const EmojiAutoCompleteItem = ({ entity }: { entity: any }) => {
   return <div>{`️${entity.native} ${entity.colons}`}</div>;
 };
-
-function isValidBotCmd(words: string[]) {
-  if (words.length !== 1) return false;
-  const action = words[0];
-  if (["on", "off"].includes(action.toLowerCase())) return true;
-  const duration: any = action.slice(0, -1);
-  const unit = action.substr(action.length - 1).toLowerCase();
-  return !isNaN(duration) && ["s", "m", "h", "d"].includes(unit);
-}
 
 async function makeChatName() {
   const adjective = "adjective";
@@ -586,67 +570,6 @@ class App extends Component<Props, State> {
           .then(() => this.chatManager.fetchUpdate())
           .then(() => this.scrollToLatestMessages());
         break;
-      case "bot":
-        if (!isValidBotCmd(words)) {
-          alert(
-            "invalid bot command. required e.g. /bot [on/off] | [5s|m|h|d]",
-          );
-          break;
-        }
-        const action = words[0].toLowerCase();
-        const allBots = await this.chatManager
-          .getPublicAutomation()
-          .then(async (res) => {
-            const bots = await res.json();
-            return bots.filter((en: any) => en.artifactHash === publicBot.hash);
-          });
-
-        if (allBots.length === 0) {
-          this.chatManager.archiveBotRequest(
-            chatUser,
-            publicBot.name,
-            false,
-            `\`${publicBot.name}\` is not available.`,
-          );
-          console.log(`public artifact: ${publicBot.hash} not found`);
-          break;
-        }
-        const theBot = allBots[0];
-        switch (action) {
-          case "on":
-            this.chatManager
-              .deployArchiveBot(theBot.owner, theBot.artifactHash)
-              .then(() => {
-                this.chatManager.archiveBotRequest(
-                  chatUser,
-                  publicBot.name,
-                  true,
-                  null,
-                );
-              });
-            break;
-          case "off":
-            this.chatManager
-              .undeployArchiveBot(theBot.artifactHash)
-              .then(() => {
-                this.chatManager.archiveBotRequest(
-                  chatUser,
-                  publicBot.name,
-                  false,
-                  null,
-                );
-              });
-            break;
-          default:
-            const duration = action.slice(0, -1);
-            const unit = action.substr(action.length - 1).toLowerCase();
-            this.chatManager.updateUserSettings(chatUser, {
-              time: duration,
-              unit: unit,
-            });
-            break;
-        }
-        break;
       default:
         if (!currentChat)
           return alert(
@@ -802,15 +725,6 @@ class App extends Component<Props, State> {
                     <td>Request a list of known users from the Operator</td>
                     <td>
                       <code>/users</code>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td>
-                      Start/Stop an archiving bot to automatically archive your
-                      expired messages
-                    </td>
-                    <td>
-                      <code>/bot [on/off] | [5s/m/h/d]</code>
                     </td>
                   </tr>
                   <tr>

--- a/web/src/ChatManager.ts
+++ b/web/src/ChatManager.ts
@@ -109,15 +109,12 @@ interface ChatManager {
     chat: { contractId: ContractId<V4.Chat> },
     slackChannelId: string,
   ): Promise<void>;
-  getPublicAutomation(): Promise<any>;
-  deployArchiveBot(owner: string, artifactHash: string): Promise<void>;
   archiveBotRequest(
     user: { contractId: ContractId<V4.User> },
     botName: string,
     enabled: boolean,
     message?: string | null,
   ): Promise<void>;
-  undeployArchiveBot(artifactHash: string): Promise<void>;
   updateUserSettings(
     user: { contractId: ContractId<V4.User> },
     timedelta: V4.Duration,
@@ -201,11 +198,6 @@ async function ChatManager(
 
   const postPublic = (url: string, options = {}) => {
     Object.assign(options, { method: "POST", headers: publicHeaders });
-    return fetch(url, options);
-  };
-
-  const getPublic = (url: string, options = {}) => {
-    Object.assign(options, { method: "GET", headers: publicHeaders });
     return fetch(url, options);
   };
 
@@ -362,23 +354,6 @@ async function ChatManager(
     } catch (e) {
       console.error("Could not fetch contracts!", e);
     }
-  };
-
-  const getPublicAutomation = async () => {
-    return getPublic("/.hub/v1/published");
-  };
-
-  const deployArchiveBot = async (owner: string, artifactHash: string) => {
-    await post("/.hub/v1/published/deploy", {
-      body: JSON.stringify({
-        artifactHash: artifactHash,
-        owner: owner,
-      }),
-    });
-  };
-
-  const undeployArchiveBot = async (artifactHash: string) => {
-    await post("/.hub/v1/published/undeploy/" + artifactHash);
   };
 
   const archiveBotRequest = async (
@@ -545,10 +520,7 @@ async function ChatManager(
     renameChat,
     archiveChat,
     forwardToSlack,
-    getPublicAutomation,
-    deployArchiveBot,
     archiveBotRequest,
-    undeployArchiveBot,
     updateUserSettings,
   };
 }


### PR DESCRIPTION
User-deployed automations are no longer supported on Daml Hub, so remove them.

This does not affect the _operator_-deployed automation of Daml Chat; operator-deployed automations continue to remain supported on Daml Hub.