### PR TITLE
Remove giphy support.

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -25,8 +25,6 @@ import { Party } from "@daml/types";
 
 const Loading = () => <div>Loading</div>;
 
-const GIPHY_TOKEN = "kDqbzOZtPvy38TLdqonPnpTPrsLfW8uy";
-
 const getAllKnownUsers = (chats: Chat[], aliases: Aliases) => {
   if (!chats) return [];
   const chatMembers = [...new Set(chats.flatMap((c) => c.chatMembers))];
@@ -464,22 +462,6 @@ class App extends Component<Props, State> {
         if (!chatToForward) return alert(`unknown chat id ${chatToForward}`);
         const slackChannelId = words.filter((w) => !w.startsWith("#")).join("");
         this.chatManager.forwardToSlack(chatToForward, slackChannelId);
-        break;
-      case "giphy":
-        if (!currentChat) return;
-        fetch(
-          `//api.giphy.com/v1/gifs/random?api_key=${GIPHY_TOKEN}&tag=${encodeURIComponent(
-            content,
-          )}`,
-        )
-          .then(async (res) => {
-            const result = await res.json();
-            const imageUrl = result.data.fixed_height_downsampled_url;
-            const message = `![${content}](${imageUrl})`;
-            this.chatManager.sendMessage(chatUser, currentChat, message);
-          })
-          .then(() => this.chatManager.fetchUpdate())
-          .then(() => this.scrollToLatestMessages());
         break;
       default:
         if (!currentChat)

--- a/web/src/components/NoChat.tsx
+++ b/web/src/components/NoChat.tsx
@@ -115,12 +115,6 @@ const NoChat: FunctionComponent<Props> = (_: Props) => (
           <th></th>
         </tr>
         <tr>
-          <td>Random GIF optionally related to tag</td>
-          <td>
-            <code>/giphy [tag]</code>
-          </td>
-        </tr>
-        <tr>
           <td>Autocomplete User or Chat</td>
           <td>
             <code>@user</code> &nbsp; <code>#chat</code>

--- a/web/src/components/autocomplete/commands.tsx
+++ b/web/src/components/autocomplete/commands.tsx
@@ -28,10 +28,6 @@ const commands: Command[] = [
     description: "create a private chat between members",
   },
   {
-    command: "/giphy [tag]",
-    description: "random GIF related to tag. Random GIF if no tag specified",
-  },
-  {
     command: "/rename [#chat-id] [new-name] [new description]",
     description: "rename a chat. (You must be the creator of the chat)",
   },


### PR DESCRIPTION
Sadly, the Giphy integration hasn't worked in a long time, probably because this token went bad.

There isn't a great way for the sample app to always include an arbitrary token we know will work, so sadly, just remove the functionality altogether.