### PR TITLE
Drop party/token based login from the Login screen of Daml Chat, since only UM 2.x is supported now.

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -343,15 +343,10 @@ textarea.message-input {
 
 .login {
   width: 500px;
+  padding: 32px;
   background-color: white;
   display: flex;
   align-items: center;
-}
-
-.login-form {
-  width: 100%;
-  margin-bottom: 0;
-  padding: 32px;
 }
 
 .login-form > * {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { BaseSyntheticEvent, Component, FormEvent, KeyboardEvent } from "react";
+import { BaseSyntheticEvent, Component, KeyboardEvent } from "react";
 import ChatManager, { Aliases, Chat, Message, User } from "./ChatManager";
 import Login from "./components/Login";
 import NewUser from "./components/NewUser";
@@ -80,8 +80,6 @@ interface CurrentChatState {
 }
 
 interface State extends CurrentChatState {
-  partyId: string;
-  token: string;
   partyName: string;
   showLogin: boolean;
   showWelcome: boolean;
@@ -92,8 +90,6 @@ interface State extends CurrentChatState {
 }
 
 const INITIAL_STATE: State = {
-  partyId: "",
-  token: "",
   partyName: "",
   showLogin: true,
   showWelcome: false,
@@ -117,7 +113,6 @@ class App extends Component<Props, State> {
     const token = cookies.get(DAMLHUB_LEDGER_ACCESS_TOKEN);
 
     this.handleInput = this.handleInput.bind(this);
-    this.handleSubmit = this.handleSubmit.bind(this);
     this.handleAcceptInvitation = this.handleAcceptInvitation.bind(this);
     this.handleSwitchToChat = this.handleSwitchToChat.bind(this);
     this.handleSubmitMessage = this.handleSubmitMessage.bind(this);
@@ -130,8 +125,6 @@ class App extends Component<Props, State> {
 
     if (token) {
       // @ts-ignore
-      this.state.token = token;
-      // @ts-ignore
       this.state.showLogin = false;
       this.createChatManager(token);
     }
@@ -142,13 +135,6 @@ class App extends Component<Props, State> {
 
     // @ts-ignore
     this.setState({ [name]: value });
-  }
-
-  handleSubmit(event: FormEvent) {
-    // @ts-ignore
-    const { token } = event.target;
-    event.preventDefault();
-    this.createChatManager(token.value);
   }
 
   handleAcceptInvitation(event: BaseSyntheticEvent) {
@@ -170,8 +156,6 @@ class App extends Component<Props, State> {
     cookies.remove(DAMLHUB_LEDGER_ACCESS_TOKEN);
     this.stopPolling();
     this.setState({
-      partyId: "",
-      token: "",
       partyName: "",
       showLogin: true,
       showWelcome: false,
@@ -197,7 +181,6 @@ class App extends Component<Props, State> {
 
   updateUser(user: User, onboarded: boolean) {
     this.setState({
-      partyId: user.user,
       partyName: user.userName,
       chatUser: user,
       showLogin: false,
@@ -471,8 +454,6 @@ class App extends Component<Props, State> {
 
   render() {
     const {
-      token,
-      partyId,
       partyName,
       showLogin,
       showWelcome,
@@ -579,13 +560,7 @@ class App extends Component<Props, State> {
           ) : null}
         </aside>
         {showLogin ? (
-          <Login
-            partyId={partyId}
-            token={token}
-            handleUserInput={this.handleInput}
-            handleTokenInput={this.handleInput}
-            handleSubmit={this.handleSubmit}
-          />
+          <Login />
         ) : showWelcome ? (
           <NewUser
             partyName={partyName}

--- a/web/src/components/Login.tsx
+++ b/web/src/components/Login.tsx
@@ -1,59 +1,15 @@
-import * as React from "react";
+import { FunctionComponent } from "react";
 
-interface Props {
-  partyId: string;
-  handleSubmit: React.FormEventHandler;
-  handleUserInput: React.ChangeEventHandler<HTMLInputElement>;
-  handleTokenInput: React.ChangeEventHandler<HTMLInputElement>;
-  token: string;
-}
+interface Props {}
 
-const Login = (props: Props) => {
-  const { partyId, handleSubmit, handleUserInput, handleTokenInput, token } =
-    props;
-
-  return (
-    <div className="login-container">
-      <div className="login">
-        <form className="login-form" onSubmit={handleSubmit}>
-          <a className="submit-btn dabl-login" href="/.hub/v2/auth/login">
-            Log In with Daml Hub
-          </a>
-          <label className="username-label" htmlFor="username">
-            OR
-          </label>
-          <label className="username-label" htmlFor="username">
-            Party
-          </label>
-          <input
-            className="username-input"
-            type="text"
-            id="username"
-            name="partyId"
-            value={partyId}
-            onChange={handleUserInput}
-            placeholder="Party ID"
-          />
-          <label className="username-label" htmlFor="username">
-            Token
-          </label>
-          <input
-            id="secret"
-            className="username-input"
-            autoFocus
-            type="password"
-            name="token"
-            value={token}
-            onChange={handleTokenInput}
-            placeholder="Party JWT"
-          />
-          <button type="submit" className="submit-btn">
-            Submit
-          </button>
-        </form>
-      </div>
+const Login: FunctionComponent<Props> = (_: Props) => (
+  <div className="login-container">
+    <div className="login">
+      <a className="submit-btn dabl-login" href="/.hub/v2/auth/login">
+        Log In with Daml Hub
+      </a>
     </div>
-  );
-};
+  </div>
+);
 
 export default Login;


### PR DESCRIPTION
Daml Chat now only understands User Management 2.x tokens, and uses User Management 2.x APIs to figure out what party it should use. That means the "traditional" way of supplying a party JWT is no longer usable, so remove those fields.